### PR TITLE
Reduce gas for callbacks

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -11,7 +11,7 @@ pub fn ntoy(near_amount: Balance) -> Balance {
     near_amount * 10u128.pow(24)
 }
 
-pub const CALLBACK: Gas = 25_000_000_000_000;
+pub const CALLBACK: Gas = 5_000_000_000_000;
 
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;


### PR DESCRIPTION
Allocating 25 TGas for callbacks means that we can't send funds to more than 10 accounts at once with the limit of 300 TGas

This PR addresses the problem by allocating for callbacks less amount of Gas (5TGas), which in turn allows the multisender contract to send to up to 30 accounts at once